### PR TITLE
verify: sev: check FMC field in TCB

### DIFF
--- a/src/sev.rs
+++ b/src/sev.rs
@@ -17,6 +17,7 @@ enum SnpOid {
     Tee,
     Snp,
     Ucode,
+    Fmc,
     HwId,
 }
 
@@ -27,6 +28,7 @@ impl SnpOid {
             SnpOid::Tee => oid!(1.3.6.1.4.1.3704.1.3.2),
             SnpOid::Snp => oid!(1.3.6.1.4.1.3704.1.3.3),
             SnpOid::Ucode => oid!(1.3.6.1.4.1.3704.1.3.8),
+            SnpOid::Fmc => oid!(1.3.6.1.4.1.3704.1.3.9),
             SnpOid::HwId => oid!(1.3.6.1.4.1.3704.1.4),
         }
     }
@@ -220,6 +222,22 @@ fn verify_tcb(vcek: &Certificate, report: &AttestationReport, opts: &VerifyOptio
         }
         if !opts.quiet {
             println!("TCB microcode matches ({})", report.reported_tcb.microcode);
+        }
+    }
+
+    if let Some(fmc) = report.reported_tcb.fmc {
+        let ext = extensions
+            .get(&SnpOid::Fmc.oid())
+            .ok_or(anyhow::anyhow!("VCEK certificate is missing the FMC field"))?;
+
+        if !check_cert_extension(ext, &fmc.to_le_bytes()) {
+            return Err(anyhow::anyhow!(
+                "TCB FMC mismatch: report={} vs certificate",
+                fmc
+            ));
+        }
+        if !opts.quiet {
+            println!("TCB FMC matches ({})", fmc);
         }
     }
 


### PR DESCRIPTION
Verify the FMC field within the reported TCB just like it is done with other fields. The FMC field is only present for Turin and newer models.